### PR TITLE
fix: 非対称のブランチを変更

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -8,7 +8,8 @@ on:
   pull_request:
     types: [opened]
     branches-ignore:
-      - develop
+      - master
+      - main
   pull_request_review_comment:
     types: [created]
   issue_comment:
@@ -37,7 +38,6 @@ jobs:
           openai_timeout_ms: 900000 # 15分.
           language: ja-JP
           path_filters: |
-            !db/**
             !**/*.lock
           system_message: |
             あなたは @coderabbitai（別名 github-actions[bot]）で、OpenAIによって訓練された言語モデルです。


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- Refactor: GitHub Actionsのトリガーブランチを変更しました。`develop`ブランチの無視設定を削除し、代わりに`master`と`main`ブランチを無視するようになりました。
- Chore: パスフィルタから`db/**`を削除し、データベース関連のファイルもレビュー対象としました。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->