### PR TITLE
GitHub Actionsに自動アップデート用の設定処理の追加

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [macos-latest, ubuntu-20.04, windows-latest]
-
+        platform: [windows-latest]
     runs-on: ${{ matrix.platform }}
+    env:
+      TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+      TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2.2.4
@@ -25,11 +27,6 @@ jobs:
           node-version: 18
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
-      - name: install dependencies (ubuntu only)
-        if: matrix.platform == 'ubuntu-20.04'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
       - name: install frontend dependencies
         run: pnpm install # change this to npm or pnpm depending on which one you use
       - uses: tauri-apps/tauri-action@v0
@@ -41,3 +38,33 @@ jobs:
           releaseBody: 'See the assets to download this version and install.'
           releaseDraft: true
           prerelease: false
+      - name: Install GitHub CLI, jq (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          choco install gh
+          choco install jq
+      # Windows用の環境変数設定
+      - name: Get version from package.json (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          echo "APP_VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
+        shell: bash
+      - name: List current directory contents
+        run: |
+          ls ./src-tauri/target/release/bundle
+      # Windows (x86_64): Update gist with app.msi.sig content and url
+      - name: Update gist with Windows (x86_64) signature and url
+        if: matrix.platform == 'windows-latest'
+        shell: bash
+        run: |
+          ls ./src-tauri/target/release/bundle/msi/
+          CONTENT=$(cat "./src-tauri/target/release/bundle/msi/setli_${{ env.APP_VERSION }}_x64_en-US.msi.zip.sig")
+          URL="https://github.com/averu/setli/releases/download/setli_${{ env.APP_VERSION }}/setli_${{ env.APP_VERSION }}_x64_en-US.msi.zip"
+          echo "${{ secrets.UPDATE_GIST_ID }}"
+          GIST_CONTENT=$(gh gist view "${{ secrets.UPDATE_GIST_ID }}" --raw | tail -n +3)
+          echo $GIST_CONTENT > temp.json
+          jq --arg CONTENT "$CONTENT" --arg URL "$URL" \
+          '.platforms.windows_x86_64.signature = $CONTENT | .platforms.windows_x86_64.url = $URL' temp.json > updated.json
+          gh gist edit "${{ secrets.UPDATE_GIST_ID }}" updated.json
+        env:
+          GH_TOKEN: ${{ secrets.GH_GIST_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - release
-
 jobs:
   publish-tauri:
     permissions:
@@ -38,21 +37,11 @@ jobs:
           releaseBody: 'See the assets to download this version and install.'
           releaseDraft: true
           prerelease: false
-      - name: Install GitHub CLI, jq (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          choco install gh
-          choco install jq
-      # Windows用の環境変数設定
       - name: Get version from package.json (Windows)
         if: runner.os == 'Windows'
         run: |
           echo "APP_VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
         shell: bash
-      - name: List current directory contents
-        run: |
-          ls ./src-tauri/target/release/bundle
-      # Windows (x86_64): Update gist with app.msi.sig content and url
       - name: Update gist with Windows (x86_64) signature and url
         if: matrix.platform == 'windows-latest'
         shell: bash


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- Refactor: GitHub Actionsの設定が更新され、実行プラットフォームがWindowsに限定されました。
- New Feature: 環境変数が追加され、Windowsでのバージョン取得とGistへの署名とURLの更新が可能になりました。
- Chore: Ubuntuでの依存関係のインストールステップが削除されました。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->